### PR TITLE
Update module google/go-github/v27 to v28

### DIFF
--- a/cmd/reviewdog/main.go
+++ b/cmd/reviewdog/main.go
@@ -18,7 +18,7 @@ import (
 
 	"golang.org/x/oauth2"
 
-	"github.com/google/go-github/v27/github"
+	"github.com/google/go-github/v28/github"
 	shellwords "github.com/mattn/go-shellwords"
 	"github.com/reviewdog/errorformat/fmts"
 	"github.com/reviewdog/reviewdog"


### PR DESCRIPTION
fixes:
```
package github.com/google/go-github/v27/github: cannot find package "github.com/google/go-github/v27/github" in any of:
	/usr/local/go/src/github.com/google/go-github/v27/github (from $GOROOT)
	/go/src/github.com/google/go-github/v27/github (from $GOPATH)
```